### PR TITLE
Alter image tables to accept large strings

### DIFF
--- a/data/migrations/20200507113256_fix_AtoE.js
+++ b/data/migrations/20200507113256_fix_AtoE.js
@@ -1,0 +1,19 @@
+
+exports.up = function(knex) {
+  knex.schema.alterTable('AtoE', tbl =>{
+    tbl.increments();
+
+  	tbl
+  	  .string('letter')
+  	  .notNullable()
+  	  .unique();
+
+      tbl.text('image').notNullable().alter();
+
+  	  //tbl.string('image').notNullable();
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists("AtoE");
+};

--- a/data/migrations/20200507113315_fix_FtoJ.js
+++ b/data/migrations/20200507113315_fix_FtoJ.js
@@ -1,0 +1,19 @@
+
+exports.up = function(knex) {
+  knex.schema.alterTable('FtoJ', tbl =>{
+    tbl.increments();
+
+  	tbl
+  	  .string('letter')
+  	  .notNullable()
+  	  .unique();
+
+      tbl.text('image').notNullable().alter();
+
+  	  //tbl.string('image').notNullable();
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists("FtoJ");
+};

--- a/data/migrations/20200507113329_fix_KtoO.js
+++ b/data/migrations/20200507113329_fix_KtoO.js
@@ -1,0 +1,19 @@
+
+exports.up = function(knex) {
+  knex.schema.alterTable('KtoO', tbl =>{
+    tbl.increments();
+
+  	tbl
+  	  .string('letter')
+  	  .notNullable()
+  	  .unique();
+
+      tbl.text('image').notNullable().alter();
+
+  	  //tbl.string('image').notNullable();
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists("KtoO");
+};

--- a/data/migrations/20200507113347_fix_PtoT.js
+++ b/data/migrations/20200507113347_fix_PtoT.js
@@ -1,0 +1,19 @@
+
+exports.up = function(knex) {
+  knex.schema.alterTable('PtoT', tbl =>{
+    tbl.increments();
+
+  	tbl
+  	  .string('letter')
+  	  .notNullable()
+  	  .unique();
+
+      tbl.text('image').notNullable().alter();
+
+  	  //tbl.string('image').notNullable();
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists("PtoT");
+};

--- a/data/migrations/20200507113400_fix_UtoZ.js
+++ b/data/migrations/20200507113400_fix_UtoZ.js
@@ -1,0 +1,19 @@
+
+exports.up = function(knex) {
+  knex.schema.alterTable('UtoZ', tbl =>{
+    tbl.increments();
+
+  	tbl
+  	  .string('letter')
+  	  .notNullable()
+  	  .unique();
+
+      tbl.text('image').notNullable().alter();
+
+  	  //tbl.string('image').notNullable();
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists("UtoZ");
+};


### PR DESCRIPTION
# Description
When running the seeds files to populate the image tables the field for the images had a default length of 255. The solution is to alter the table to remove that limitation.

Fixes # (31)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Testing of code on the backend staging server to be conducted after deployment
- [ ] Test B

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
