### PR TITLE
Dissable CORB from blocking images via noSniff

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -26,7 +26,7 @@ const configureRoutes = require("../routes/router");
 
 const server = express();
 
-server.use(helmet());
+server.use(helmet.noSniff());//Disables CORB from blocking images
 server.use(morgan("combined"));
 server.use(express.json());
 server.use(cors());


### PR DESCRIPTION
# Description
CORB was blocking the sign images the solution is to add .noSniff helmet.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?

# Checklist

- [x] My changes generate no new warnings
- [x] There are no merge conflicts
